### PR TITLE
1 ensure the role works fine with ansible 217x

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,29 @@ An ansible role to install opensc packages and enable the opensc service.
 * GNU/Linux
 * FreeBSD
 
+## Installation
+
+### Ansible galaxy
+
+The role is available on [Ansible Galaxy](https://galaxy.ansible.com/ui/standalone/roles/stafwag/opensc).
+
+To install the role from Ansible Galaxy execute the command below. 
+
+```bash
+ansible-galaxy install stafwag.opensc
+```
+### Source Code
+
+If you want to use the source code directly.
+
+Clone the role source code.
+
+```bash
+$ git clone https://github.com/stafwag/ansible-role-opensc
+```
+
+and put into the [role search path](https://docs.ansible.com/ansible/2.4/playbooks_reuse_roles.html#role-search-path)
+
 ## Role Variables
 
 None
@@ -21,7 +44,7 @@ None
 
 ```
 ---
-- name: setup ansible server
+- name: Setup ansible server
   hosts: ansible
   become: true
   roles:
@@ -33,4 +56,4 @@ MIT/BSD
 
 ## Author Information
 
-Created by Staf Wagemakers, email: staf@wagemakers.be, website: http://www.wagemakers.be.
+Created by Staf Wagemakers, email: staf@wagemakers.be, website: https://www.wagemakers.be, my company https://mask27.dev

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,0 @@
----
-# defaults file for opensc

--- a/doc/examples/setup_opensc.yml
+++ b/doc/examples/setup_opensc.yml
@@ -1,0 +1,6 @@
+---
+- name: Setup opensc
+  hosts: localhost
+  become: true
+  roles:
+        - stafwag.opensc

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,0 @@
----
-# handlers file for opensc

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,10 +1,38 @@
+---
 galaxy_info:
   role_name: opensc
+  namespace: stafwag
   author: staf wagemakers <staf@wagemakers.be>
-  description: An ansible role to set up opensc
+  description: An ansible role to manage opensc
   license: license (BSD, MIT)
-  min_ansible_version: 2.4
+  min_ansible_version: "2.4"
+  platforms:
+    - name: EL
+      versions:
+        - "all"
+    - name: Fedora
+      versions:
+        - "all"
+    - name: Debian
+      versions:
+        - "all"
+    - name: Ubuntu
+      versions:
+        - "all"
+    - name: opensuse
+      versions:
+        - "all"
+    - name: SLES
+      versions:
+        - "all"
+    - name: ArchLinux
+      versions:
+        - "all"
+    - name: FreeBSD
+      versions:
+        - "all"
   galaxy_tags:
     - system
     - security
+    - opensc
 dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,23 +1,22 @@
 ---
 # tasks file for opensc
 
-- name: set OS related variables
-  include_vars: '{{ item }}'
+- name: Set OS related variables
+  ansible.builtin.include_vars: "{{ item }}"
   with_first_found:
-    - '{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml'
-    - '{{ ansible_distribution }}.yml'
-    - '{{ ansible_os_family }}.yml'
-    - '{{ ansible_os_family | replace ("/","_") | replace(" ","_") }}.yml'
+    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
+    - "{{ ansible_distribution }}.yml"
+    - "{{ ansible_os_family }}.yml"
     - defaults.yml
 
-- name: install the required packages
-  package:
-    name: '{{ item }}'
+- name: Install the required packages
+  ansible.builtin.package:
+    name: "{{ item }}"
     state: latest
   with_items: "{{ opensc_packages }}"
 
-- name: enable opensc service
-  service:
-    name: '{{ opensc_service }}'
+- name: Enable opensc service
+  ansible.builtin.service:
+    name: "{{ opensc_service }}"
     state: started
     enabled: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,11 +12,11 @@
 - name: Install the required packages
   ansible.builtin.package:
     name: "{{ item }}"
-    state: latest
+    state: present
   with_items: "{{ opensc_packages }}"
 
 - name: Enable opensc service
   ansible.builtin.service:
     name: "{{ opensc_service }}"
     state: started
-    enabled: yes
+    enabled: true

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,2 +1,0 @@
-localhost
-

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,0 @@
----
-- hosts: localhost
-  remote_user: root
-  roles:
-    - opensc

--- a/vars/defaults.yml
+++ b/vars/defaults.yml
@@ -1,4 +1,4 @@
 opensc_packages:
   - opensc
   - ccid
-opensc_service: pcscd 
+opensc_service: pcscd

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,0 @@
----
-# vars file for opensc


### PR DESCRIPTION
Corrected ansible-lint errors
    
* Corrected ansible-lint errors
* Removed "empty" files
* Removed replace space to include ansible_os_family.
  It was used for Kali GNU/Linux, Kali is reported as Debian now.
* Updated README
* Added doc/examples